### PR TITLE
fix compiler warning

### DIFF
--- a/lib/compilers/node.ex
+++ b/lib/compilers/node.ex
@@ -113,7 +113,7 @@ else
     @behaviour MjmlEEx.Compiler
 
     @impl true
-    def compile(mjml_template) do
+    def compile(_mjml_template) do
       raise("""
       In order to use the Node compiler you must also update your mix.exs file like so:
 


### PR DESCRIPTION
```
warning: variable "mjml_template" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/compilers/node.ex:116: MjmlEEx.Compilers.Node.compile/1
```